### PR TITLE
Fix the name of access token env variable to PRONTO_GITHUB_ACCESS_TOKEN

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ test:
     - bundle exec pronto-circleci
 ```
 
-And finally setup an environment variable with a [Github access token](https://help.github.com/articles/creating-an-access-token-for-command-line-use) in the [circleci environment configuration](https://circleci.com/docs/1.0/environment-variables/) of your repo with the name of: `GITHUB_ACCESS_TOKEN`.
+And finally setup an environment variable with a [Github access token](https://help.github.com/articles/creating-an-access-token-for-command-line-use) in the [circleci environment configuration](https://circleci.com/docs/1.0/environment-variables/) of your repo with the name of: `PRONTO_GITHUB_ACCESS_TOKEN`.
 
 
 ## Usage


### PR DESCRIPTION
From GITHUB_ACCESS_TOKEN

Was renamed in `0.8.0`: https://github.com/prontolabs/pronto/blob/master/CHANGELOG.md#changes-3