### PR TITLE
fixing build errors when no pull request is present

### DIFF
--- a/lib/pronto/circleci.rb
+++ b/lib/pronto/circleci.rb
@@ -10,7 +10,8 @@ module Pronto
     end
 
     def pull_requests_urls
-      ENV['CI_PULL_REQUESTS'].split(',')
+      return ENV['CI_PULL_REQUESTS'].split(',') if ENV['CI_PULL_REQUESTS'].present?
+      return []
     end
 
     def gem_root

--- a/lib/pronto/circleci.rb
+++ b/lib/pronto/circleci.rb
@@ -10,7 +10,7 @@ module Pronto
     end
 
     def pull_requests_urls
-      return ENV['CI_PULL_REQUESTS'].split(',') if ENV['CI_PULL_REQUESTS'].present?
+      return ENV['CI_PULL_REQUESTS'].split(',') if ENV.key?('CI_PULL_REQUESTS')
       return []
     end
 

--- a/lib/pronto/circleci/version.rb
+++ b/lib/pronto/circleci/version.rb
@@ -1,5 +1,5 @@
 module Pronto
   module CircleCI
-    VERSION = "1.0.0"
+    VERSION = "1.0.0.1"
   end
 end


### PR DESCRIPTION
Currently there is a bug that breaks builds if there isn't any pull request urls in the CI_PULL_REQUESTS environment variable.

I've just added a check to make sure the environment variable is set before trying to split it, and return an empty array if the environment variable is null. This stops an exception being thrown, and therefore doesn't fail any builds.