### PR TITLE
Rename access token env variable to PRONTO_GITHUB_ACCESS_TOKEN

### DIFF
--- a/lib/pronto/circleci/pull_request.rb
+++ b/lib/pronto/circleci/pull_request.rb
@@ -6,7 +6,7 @@ module Pronto
   module CircleCI
     class PullRequest
       GITHUB_API_URL = 'https://api.github.com/repos/%{org}/%{repo}/pulls/'\
-        "%{pull_request_id}?access_token=#{ENV['GITHUB_ACCESS_TOKEN']}".freeze
+        "%{pull_request_id}?access_token=#{ENV['PRONTO_GITHUB_ACCESS_TOKEN']}".freeze
 
       attr_reader :id, :base_branch
 

--- a/spec/support/environment.rb
+++ b/spec/support/environment.rb
@@ -1,4 +1,4 @@
 require_relative 'github_mock'
 
-ENV['GITHUB_ACCESS_TOKEN'] = GithubMock.access_token
+ENV['PRONTO_GITHUB_ACCESS_TOKEN'] = GithubMock.access_token
 ENV['CI_PULL_REQUESTS'] = GithubMock.pull_requests_urls.join(',')


### PR DESCRIPTION
By adding PRONTO_ to GITHUB_ACCESS_TOKEN
Previously only renamed in README, assuming there's no usage in code.
https://github.com/comparaonline/pronto-circleci/pull/2